### PR TITLE
Add refundable to invoices

### DIFF
--- a/app/controllers/counselling/checkout_controller.rb
+++ b/app/controllers/counselling/checkout_controller.rb
@@ -5,6 +5,7 @@ module Counselling
     before_action :authenticate_user!
     before_action :auth_user_access, except: [:refund]
     before_action :auth_admin, only: [:refund]
+    before_action :check_refundable, only: [:refund]
 
     def create
       invoice = Invoice.find(params[:invoice_id].to_i)
@@ -95,6 +96,13 @@ module Counselling
       return if current_user.admin
 
       render_response(401, 'You are not authorized to do this action', :unauthorized, nil)
+    end
+
+    def check_refundable
+      invoice = Invoice.find(params[:invoice_id])
+      return if invoice.refundable
+
+      render_response(400, 'This payment is not refundable', :bad_request, nil)
     end
 
     def auth_user_access

--- a/app/controllers/counselling/checkout_controller.rb
+++ b/app/controllers/counselling/checkout_controller.rb
@@ -3,7 +3,8 @@
 module Counselling
   class CheckoutController < ApplicationController
     before_action :authenticate_user!
-    before_action :auth_user_access
+    before_action :auth_user_access, except: [:refund]
+    before_action :auth_admin, only: [:refund]
 
     def create
       invoice = Invoice.find(params[:invoice_id].to_i)
@@ -35,7 +36,10 @@ module Counselling
       @session = Stripe::Checkout::Session.retrieve(params[:session_id])
       @payment_intent = Stripe::PaymentIntent.retrieve(@session.payment_intent)
 
-      invoice.update(status: 'paid') if @payment_intent.status == 'succeeded'
+      if @payment_intent.status == 'succeeded'
+        invoice.update(status: 'paid', payment_intent_id: @payment_intent.id, refundable: true)
+      end
+
       render json: { status: session.status, customer_email: session.customer_details.email }
     rescue Stripe::StripeError => e
       Rails.logger.error("Stripe error during charge: #{e.message}")
@@ -43,6 +47,27 @@ module Counselling
     rescue StandardError => e
       Rails.logger.error("Failed to create order for user: #{e.message}")
       refund_payment(payment_intent_id)
+    end
+
+    def refund
+      invoice = Invoice.find(params[:invoice_id])
+      refund = Stripe::Refund.create(
+        {
+          payment_intent: invoice.payment_intent_id
+        }
+      )
+      if refund.status == 'succeeded'
+        Rails.logger.info("Payment was refunded: #{refund.id}")
+        invoice.update(status: 'refunded', refundable: false)
+        render_response(200, 'Payment refunded successfully', :ok, invoice)
+      else
+        Rails.logger.warn("Failed to refund payment for payment intent: #{payment_intent_id}")
+        render_response(400, 'Failed to refund payment', :bad_request, invoice)
+      end
+    rescue Stripe::StripeError => e
+      Rails.logger.error("Stripe error during charge: #{e.message}")
+    rescue StandardError => e
+      Rails.logger.error("Failed to update invoice for user: #{e.message}")
     end
 
     def cancel; end
@@ -64,6 +89,12 @@ module Counselling
       Rails.logger.error("Stripe error while refunding: #{e.message}")
     rescue StandardError => e
       Rails.logger.error("General error while refunding: #{e.message}")
+    end
+
+    def auth_admin
+      return if current_user.admin
+
+      render_response(401, 'You are not authorized to do this action', :unauthorized, nil)
     end
 
     def auth_user_access

--- a/app/controllers/store/checkout_controller.rb
+++ b/app/controllers/store/checkout_controller.rb
@@ -86,6 +86,13 @@ module Store
       Rails.logger.error("Failed to create order for user: #{e.message}")
     end
 
+    def check_refundable
+      order = Order.find(params[:order_id])
+      return if order.refundable
+
+      render_response(400, 'This payment is not refundable', :bad_request, nil)
+    end
+
     def auth_admin
       return if current_user.admin
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -36,6 +36,7 @@ Rails.application.routes.draw do
   get '/invoices/:invoice_id/download_pdf', to: 'counselling/invoices#download_pdf'
   post '/invoices/:invoice_id/create_checkout_session', to: 'counselling/checkout#create'
   get '/invoices/:invoice_id/session-status', to: 'counselling/checkout#session_status'
+  get '/invoices/:invoice_id/refund', to: 'counselling/checkout#refund'
 
   # Users
   get '/my_chats', to: 'counselling/private_messages#list_chats'

--- a/db/migrate/20240115205611_remove_stripe_customer_id_from_invoices.rb
+++ b/db/migrate/20240115205611_remove_stripe_customer_id_from_invoices.rb
@@ -1,0 +1,5 @@
+class RemoveStripeCustomerIdFromInvoices < ActiveRecord::Migration[7.1]
+  def change
+    remove_column :invoices, :stripe_customer_id, :string
+  end
+end

--- a/db/migrate/20240115205627_add_refundable_to_invoices.rb
+++ b/db/migrate/20240115205627_add_refundable_to_invoices.rb
@@ -1,0 +1,5 @@
+class AddRefundableToInvoices < ActiveRecord::Migration[7.1]
+  def change
+    add_column :invoices, :refundable, :boolean, default: false
+  end
+end

--- a/db/migrate/20240115205658_add_payment_intent_id_to_invoices.rb
+++ b/db/migrate/20240115205658_add_payment_intent_id_to_invoices.rb
@@ -1,0 +1,5 @@
+class AddPaymentIntentIdToInvoices < ActiveRecord::Migration[7.1]
+  def change
+    add_column :invoices, :payment_intent_id, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_01_15_194124) do
+ActiveRecord::Schema[7.1].define(version: 2024_01_15_205658) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -82,7 +82,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_01_15_194124) do
     t.bigint "admin_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.string "stripe_customer_id"
+    t.boolean "refundable", default: false
+    t.string "payment_intent_id"
     t.index ["admin_id"], name: "index_invoices_on_admin_id"
     t.index ["client_id"], name: "index_invoices_on_client_id"
   end


### PR DESCRIPTION

### What does this PR do?
##### adds:
- payment_intent_id column to invoices
- refundable column to invoices
- refund method to counselling/checkout
- refund endpoint for invoices ('/invoices/:invoice_id/refund')
##### remove: 
- stripe_customer_id column from invoices

### Where should the reviewer start?
mainly migrations and counselling/checkout_controller
